### PR TITLE
feat: redirect user to page list when sign in

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -94,7 +94,7 @@ const LoginForm = ({ signInHandler, toggleRegister, error, loading }: IState) =>
 
   useEffect(() => {
     if (isAuthenticated) {
-      history.push('/')
+      history.push('/list')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated])


### PR DESCRIPTION
Solves #24 issue

Keeps the normal flow when user sign up, but change the homepage to /list when the user sign in.